### PR TITLE
Validate context if there is any of the requested space types available

### DIFF
--- a/src/magic_uv/common.py
+++ b/src/magic_uv/common.py
@@ -43,6 +43,12 @@ def is_console_mode():
         return False
     return os.environ["MUV_CONSOLE_MODE"] == "true"
 
+def is_valid_space(context, allowed_spaces):
+    for area in context.screen.areas:
+        for space in area.spaces:
+            if space.type in allowed_spaces:
+                return True
+    return False
 
 def is_debug_mode():
     return __DEBUG_MODE

--- a/src/magic_uv/common.py
+++ b/src/magic_uv/common.py
@@ -50,6 +50,7 @@ def is_valid_space(context, allowed_spaces):
                 return True
     return False
 
+
 def is_debug_mode():
     return __DEBUG_MODE
 

--- a/src/magic_uv/common.py
+++ b/src/magic_uv/common.py
@@ -43,6 +43,7 @@ def is_console_mode():
         return False
     return os.environ["MUV_CONSOLE_MODE"] == "true"
 
+
 def is_valid_space(context, allowed_spaces):
     for area in context.screen.areas:
         for space in area.spaces:

--- a/src/magic_uv/op/align_uv.py
+++ b/src/magic_uv/op/align_uv.py
@@ -50,10 +50,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/align_uv_cursor.py
+++ b/src/magic_uv/op/align_uv_cursor.py
@@ -33,19 +33,14 @@ from ..utils.bl_class_registry import BlClassRegistry
 from ..utils.property_class_registry import PropertyClassRegistry
 from ..utils import compatibility as compat
 
-
 def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    # after the execution    
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True
-
 
 @PropertyClassRegistry()
 class _Properties:

--- a/src/magic_uv/op/align_uv_cursor.py
+++ b/src/magic_uv/op/align_uv_cursor.py
@@ -32,6 +32,8 @@ from .. import common
 from ..utils.bl_class_registry import BlClassRegistry
 from ..utils.property_class_registry import PropertyClassRegistry
 from ..utils import compatibility as compat
+
+
 def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf

--- a/src/magic_uv/op/align_uv_cursor.py
+++ b/src/magic_uv/op/align_uv_cursor.py
@@ -36,7 +36,7 @@ from ..utils import compatibility as compat
 def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution    
+    # after the execution
     if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 

--- a/src/magic_uv/op/align_uv_cursor.py
+++ b/src/magic_uv/op/align_uv_cursor.py
@@ -41,6 +41,7 @@ def _is_valid_context(context):
 
     return True
 
+
 @PropertyClassRegistry()
 class _Properties:
     idname = "align_uv_cursor"

--- a/src/magic_uv/op/align_uv_cursor.py
+++ b/src/magic_uv/op/align_uv_cursor.py
@@ -32,7 +32,6 @@ from .. import common
 from ..utils.bl_class_registry import BlClassRegistry
 from ..utils.property_class_registry import PropertyClassRegistry
 from ..utils import compatibility as compat
-
 def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf

--- a/src/magic_uv/op/clip_uv.py
+++ b/src/magic_uv/op/clip_uv.py
@@ -49,10 +49,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/copy_paste_uv.py
+++ b/src/magic_uv/op/copy_paste_uv.py
@@ -49,10 +49,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/copy_paste_uv.py
+++ b/src/magic_uv/op/copy_paste_uv.py
@@ -49,7 +49,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/copy_paste_uv_object.py
+++ b/src/magic_uv/op/copy_paste_uv_object.py
@@ -54,10 +54,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/copy_paste_uv_uvedit.py
+++ b/src/magic_uv/op/copy_paste_uv_uvedit.py
@@ -48,10 +48,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/flip_rotate_uv.py
+++ b/src/magic_uv/op/flip_rotate_uv.py
@@ -46,10 +46,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/mirror_uv.py
+++ b/src/magic_uv/op/mirror_uv.py
@@ -48,10 +48,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/move_uv.py
+++ b/src/magic_uv/op/move_uv.py
@@ -44,10 +44,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/pack_uv.py
+++ b/src/magic_uv/op/pack_uv.py
@@ -53,10 +53,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/preserve_uv_aspect.py
+++ b/src/magic_uv/op/preserve_uv_aspect.py
@@ -44,10 +44,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/select_uv.py
+++ b/src/magic_uv/op/select_uv.py
@@ -44,10 +44,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/smooth_uv.py
+++ b/src/magic_uv/op/smooth_uv.py
@@ -45,10 +45,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/texture_lock.py
+++ b/src/magic_uv/op/texture_lock.py
@@ -197,10 +197,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/texture_projection.py
+++ b/src/magic_uv/op/texture_projection.py
@@ -133,10 +133,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/texture_wrap.py
+++ b/src/magic_uv/op/texture_wrap.py
@@ -45,10 +45,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/transfer_uv.py
+++ b/src/magic_uv/op/transfer_uv.py
@@ -46,10 +46,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/unwrap_constraint.py
+++ b/src/magic_uv/op/unwrap_constraint.py
@@ -45,10 +45,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/uv_bounding_box.py
+++ b/src/magic_uv/op/uv_bounding_box.py
@@ -59,10 +59,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/uv_inspection.py
+++ b/src/magic_uv/op/uv_inspection.py
@@ -53,10 +53,7 @@ def _is_valid_context(context):
     # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
     # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
     # after the execution
-    for space in context.area.spaces:
-        if (space.type == 'IMAGE_EDITOR') or (space.type == 'VIEW_3D'):
-            break
-    else:
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/uv_sculpt.py
+++ b/src/magic_uv/op/uv_sculpt.py
@@ -60,10 +60,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/uvw.py
+++ b/src/magic_uv/op/uvw.py
@@ -50,10 +50,7 @@ def _is_valid_context(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/world_scale_uv.py
+++ b/src/magic_uv/op/world_scale_uv.py
@@ -52,10 +52,7 @@ def _is_valid_context_for_measure(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True
@@ -71,10 +68,7 @@ def _is_valid_context_for_apply(context):
         return False
 
     # only 'VIEW_3D' space is allowed to execute
-    for space in context.area.spaces:
-        if space.type == 'VIEW_3D':
-            break
-    else:
+    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True


### PR DESCRIPTION
I put this function into common:

```
def is_valid_space(context, allowed_spaces):
    for area in context.screen.areas:
        for space in area.spaces:
            if space.type in allowed_spaces:
                return True
    return False
```

And use it in all the operators.