### PR TITLE
Moved valid space checks before object attribute checks in operator polls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.pylintArgs": [
+        "--rcfile=\"./.pylintrc\""
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    "python.linting.pylintArgs": [
-        "--rcfile=\"./.pylintrc\""
-    ]
-}

--- a/src/magic_uv/op/align_uv.py
+++ b/src/magic_uv/op/align_uv.py
@@ -44,18 +44,18 @@ from .. import common
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/clip_uv.py
+++ b/src/magic_uv/op/clip_uv.py
@@ -180,8 +180,8 @@ class MUV_OT_ClipUV(bpy.types.Operator):
 
                 selected_loops = [
                     l for l in face.loops
-                    if l[uv_layer].select
-                    or context.scene.tool_settings.use_uv_select_sync
+                    if l[uv_layer].select or
+                    context.scene.tool_settings.use_uv_select_sync
                 ]
                 if not selected_loops:
                     continue

--- a/src/magic_uv/op/clip_uv.py
+++ b/src/magic_uv/op/clip_uv.py
@@ -43,7 +43,7 @@ def _is_valid_context(context):
     # after the execution
     if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
-    
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False

--- a/src/magic_uv/op/clip_uv.py
+++ b/src/magic_uv/op/clip_uv.py
@@ -38,18 +38,18 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+    
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True
@@ -180,8 +180,8 @@ class MUV_OT_ClipUV(bpy.types.Operator):
 
                 selected_loops = [
                     l for l in face.loops
-                    if l[uv_layer].select or
-                    context.scene.tool_settings.use_uv_select_sync
+                    if l[uv_layer].select
+                    or context.scene.tool_settings.use_uv_select_sync
                 ]
                 if not selected_loops:
                     continue

--- a/src/magic_uv/op/copy_paste_uv.py
+++ b/src/magic_uv/op/copy_paste_uv.py
@@ -39,6 +39,10 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:
@@ -46,10 +50,6 @@ def _is_valid_context(context):
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True
@@ -155,8 +155,8 @@ def get_dest_face_info(ops_obj, bm, uv_layers, src_info, strategy,
         if strategy == 'N_N' and src_face_count != dest_face_count:
             ops_obj.report(
                 {'WARNING'},
-                "Number of selected faces is different from copied" +
-                "(src:{}, dest:{})"
+                "Number of selected faces is different from copied"
+                + "(src:{}, dest:{})"
                 .format(src_face_count, dest_face_count))
             return None
         dest_info[layer.name] = face_info
@@ -206,8 +206,8 @@ def _get_select_history_dest_face_info(ops_obj, bm, uv_layers, src_info,
         if strategy == 'N_N' and src_face_count != dest_face_count:
             ops_obj.report(
                 {'WARNING'},
-                "Number of selected faces is different from copied" +
-                "(src:{}, dest:{})"
+                "Number of selected faces is different from copied"
+                + "(src:{}, dest:{})"
                 .format(src_face_count, dest_face_count))
             return None
         dest_info[layer.name] = face_info

--- a/src/magic_uv/op/copy_paste_uv.py
+++ b/src/magic_uv/op/copy_paste_uv.py
@@ -155,8 +155,8 @@ def get_dest_face_info(ops_obj, bm, uv_layers, src_info, strategy,
         if strategy == 'N_N' and src_face_count != dest_face_count:
             ops_obj.report(
                 {'WARNING'},
-                "Number of selected faces is different from copied"
-                + "(src:{}, dest:{})"
+                "Number of selected faces is different from copied" +
+                "(src:{}, dest:{})"
                 .format(src_face_count, dest_face_count))
             return None
         dest_info[layer.name] = face_info
@@ -206,8 +206,8 @@ def _get_select_history_dest_face_info(ops_obj, bm, uv_layers, src_info,
         if strategy == 'N_N' and src_face_count != dest_face_count:
             ops_obj.report(
                 {'WARNING'},
-                "Number of selected faces is different from copied"
-                + "(src:{}, dest:{})"
+                "Number of selected faces is different from copied" +
+                "(src:{}, dest:{})"
                 .format(src_face_count, dest_face_count))
             return None
         dest_info[layer.name] = face_info

--- a/src/magic_uv/op/copy_paste_uv_object.py
+++ b/src/magic_uv/op/copy_paste_uv_object.py
@@ -44,6 +44,10 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:
@@ -53,9 +57,6 @@ def _is_valid_context(context):
     if context.object.mode != 'OBJECT':
         return False
 
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
-        return False
 
     return True
 

--- a/src/magic_uv/op/copy_paste_uv_object.py
+++ b/src/magic_uv/op/copy_paste_uv_object.py
@@ -57,7 +57,6 @@ def _is_valid_context(context):
     if context.object.mode != 'OBJECT':
         return False
 
-
     return True
 
 

--- a/src/magic_uv/op/copy_paste_uv_uvedit.py
+++ b/src/magic_uv/op/copy_paste_uv_uvedit.py
@@ -54,7 +54,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-
     return True
 
 

--- a/src/magic_uv/op/copy_paste_uv_uvedit.py
+++ b/src/magic_uv/op/copy_paste_uv_uvedit.py
@@ -44,7 +44,7 @@ def _is_valid_context(context):
     # after the execution
     if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
-    
+
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:

--- a/src/magic_uv/op/copy_paste_uv_uvedit.py
+++ b/src/magic_uv/op/copy_paste_uv_uvedit.py
@@ -39,6 +39,12 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+    
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:
@@ -48,11 +54,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
-        return False
 
     return True
 

--- a/src/magic_uv/op/flip_rotate_uv.py
+++ b/src/magic_uv/op/flip_rotate_uv.py
@@ -37,16 +37,16 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/mirror_uv.py
+++ b/src/magic_uv/op/mirror_uv.py
@@ -275,7 +275,7 @@ class MUV_OT_MirrorUV(bpy.types.Operator):
                             continue
                         src.x = -src.x
                     elif axis == 'Y':
-                        if ((dst.y > 0 and src.y > 0) or 
+                        if ((dst.y > 0 and src.y > 0) or
                                 (dst.y < 0 and src.y < 0)):
                             continue
                         src.y = -src.y

--- a/src/magic_uv/op/mirror_uv.py
+++ b/src/magic_uv/op/mirror_uv.py
@@ -270,18 +270,18 @@ class MUV_OT_MirrorUV(bpy.types.Operator):
 
                     # invert source axis
                     if axis == 'X':
-                        if ((dst.x > 0 and src.x > 0)
-                                or (dst.x < 0 and src.x < 0)):
+                        if ((dst.x > 0 and src.x > 0) or
+                                (dst.x < 0 and src.x < 0)):
                             continue
                         src.x = -src.x
                     elif axis == 'Y':
-                        if ((dst.y > 0 and src.y > 0)
-                                or (dst.y < 0 and src.y < 0)):
+                        if ((dst.y > 0 and src.y > 0) or 
+                                (dst.y < 0 and src.y < 0)):
                             continue
                         src.y = -src.y
                     elif axis == 'Z':
-                        if ((dst.z > 0 and src.z > 0)
-                                or (dst.z < 0 and src.z < 0)):
+                        if ((dst.z > 0 and src.z > 0) or
+                                (dst.z < 0 and src.z < 0)):
                             continue
                         src.z = -src.z
 

--- a/src/magic_uv/op/mirror_uv.py
+++ b/src/magic_uv/op/mirror_uv.py
@@ -39,16 +39,16 @@ from .. import common
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True
@@ -270,18 +270,18 @@ class MUV_OT_MirrorUV(bpy.types.Operator):
 
                     # invert source axis
                     if axis == 'X':
-                        if ((dst.x > 0 and src.x > 0) or
-                                (dst.x < 0 and src.x < 0)):
+                        if ((dst.x > 0 and src.x > 0)
+                                or (dst.x < 0 and src.x < 0)):
                             continue
                         src.x = -src.x
                     elif axis == 'Y':
-                        if ((dst.y > 0 and src.y > 0) or
-                                (dst.y < 0 and src.y < 0)):
+                        if ((dst.y > 0 and src.y > 0)
+                                or (dst.y < 0 and src.y < 0)):
                             continue
                         src.y = -src.y
                     elif axis == 'Z':
-                        if ((dst.z > 0 and src.z > 0) or
-                                (dst.z < 0 and src.z < 0)):
+                        if ((dst.z > 0 and src.z > 0)
+                                or (dst.z < 0 and src.z < 0)):
                             continue
                         src.z = -src.z
 

--- a/src/magic_uv/op/move_uv.py
+++ b/src/magic_uv/op/move_uv.py
@@ -34,6 +34,10 @@ from ..utils.property_class_registry import PropertyClassRegistry
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:
@@ -41,10 +45,6 @@ def _is_valid_context(context):
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/pack_uv.py
+++ b/src/magic_uv/op/pack_uv.py
@@ -57,7 +57,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-
     return True
 
 

--- a/src/magic_uv/op/pack_uv.py
+++ b/src/magic_uv/op/pack_uv.py
@@ -48,7 +48,7 @@ def _is_valid_context(context):
     # after the execution
     if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
-    
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False

--- a/src/magic_uv/op/pack_uv.py
+++ b/src/magic_uv/op/pack_uv.py
@@ -43,6 +43,12 @@ from .. import common
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+    
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
@@ -51,11 +57,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
-        return False
 
     return True
 

--- a/src/magic_uv/op/preserve_uv_aspect.py
+++ b/src/magic_uv/op/preserve_uv_aspect.py
@@ -35,6 +35,10 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+        
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
@@ -43,9 +47,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
-        return False
 
     return True
 

--- a/src/magic_uv/op/preserve_uv_aspect.py
+++ b/src/magic_uv/op/preserve_uv_aspect.py
@@ -38,7 +38,7 @@ def _is_valid_context(context):
     # only 'VIEW_3D' space is allowed to execute
     if not common.is_valid_space(context, ['VIEW_3D']):
         return False
-        
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False

--- a/src/magic_uv/op/preserve_uv_aspect.py
+++ b/src/magic_uv/op/preserve_uv_aspect.py
@@ -47,7 +47,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-
     return True
 
 

--- a/src/magic_uv/op/select_uv.py
+++ b/src/magic_uv/op/select_uv.py
@@ -34,18 +34,18 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/smooth_uv.py
+++ b/src/magic_uv/op/smooth_uv.py
@@ -34,6 +34,12 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+        
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
@@ -42,11 +48,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
-        return False
 
     return True
 

--- a/src/magic_uv/op/smooth_uv.py
+++ b/src/magic_uv/op/smooth_uv.py
@@ -48,7 +48,6 @@ def _is_valid_context(context):
     if context.object.mode != 'EDIT':
         return False
 
-
     return True
 
 

--- a/src/magic_uv/op/smooth_uv.py
+++ b/src/magic_uv/op/smooth_uv.py
@@ -39,7 +39,7 @@ def _is_valid_context(context):
     # after the execution
     if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
-        
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False

--- a/src/magic_uv/op/texture_lock.py
+++ b/src/magic_uv/op/texture_lock.py
@@ -188,16 +188,16 @@ def _calc_tri_vert(v0, v1, angle0, angle1):
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/texture_projection.py
+++ b/src/magic_uv/op/texture_projection.py
@@ -155,16 +155,16 @@ def _create_affine_matrix(identity, scale, rotate, translate):
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/texture_wrap.py
+++ b/src/magic_uv/op/texture_wrap.py
@@ -35,6 +35,10 @@ from ..utils.property_class_registry import PropertyClassRegistry
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:
@@ -42,10 +46,6 @@ def _is_valid_context(context):
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/transfer_uv.py
+++ b/src/magic_uv/op/transfer_uv.py
@@ -36,6 +36,10 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:
@@ -43,10 +47,6 @@ def _is_valid_context(context):
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/unwrap_constraint.py
+++ b/src/magic_uv/op/unwrap_constraint.py
@@ -36,16 +36,16 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/uv_bounding_box.py
+++ b/src/magic_uv/op/uv_bounding_box.py
@@ -442,8 +442,8 @@ class StateNone(StateBase):
                         arr = [1, 3, 6, 8]
                         if i in arr:
                             return (
-                                State.UNIFORM_SCALING_1
-                                + arr.index(i)
+                                State.UNIFORM_SCALING_1 +
+                                arr.index(i)
                             )
                     else:
                         return State.TRANSLATING + i
@@ -579,8 +579,8 @@ class StateManager:
             obj = StateRotating(self.__cmd_exec, ctrl_points)
         elif next_state == State.NONE:
             obj = StateNone(self.__cmd_exec)
-        elif (State.UNIFORM_SCALING_1 <= next_state
-              <= State.UNIFORM_SCALING_4):
+        elif (State.UNIFORM_SCALING_1 <= next_state <=
+              State.UNIFORM_SCALING_4):
             obj = StateUniformScaling(
                 self.__cmd_exec, next_state, ctrl_points)
 

--- a/src/magic_uv/op/uv_bounding_box.py
+++ b/src/magic_uv/op/uv_bounding_box.py
@@ -46,6 +46,12 @@ MAX_VALUE = 100000.0
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+
     obj = context.object
 
     # only edit mode is allowed to execute
@@ -54,12 +60,6 @@ def _is_valid_context(context):
     if obj.type != 'MESH':
         return False
     if context.object.mode != 'EDIT':
-        return False
-
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True
@@ -442,8 +442,8 @@ class StateNone(StateBase):
                         arr = [1, 3, 6, 8]
                         if i in arr:
                             return (
-                                State.UNIFORM_SCALING_1 +
-                                arr.index(i)
+                                State.UNIFORM_SCALING_1
+                                + arr.index(i)
                             )
                     else:
                         return State.TRANSLATING + i
@@ -579,8 +579,8 @@ class StateManager:
             obj = StateRotating(self.__cmd_exec, ctrl_points)
         elif next_state == State.NONE:
             obj = StateNone(self.__cmd_exec)
-        elif (State.UNIFORM_SCALING_1 <= next_state <=
-              State.UNIFORM_SCALING_4):
+        elif (State.UNIFORM_SCALING_1 <= next_state
+              <= State.UNIFORM_SCALING_4):
             obj = StateUniformScaling(
                 self.__cmd_exec, next_state, ctrl_points)
 

--- a/src/magic_uv/op/uv_inspection.py
+++ b/src/magic_uv/op/uv_inspection.py
@@ -441,9 +441,9 @@ class MUV_OT_UVInspection_PaintUVIsland(bpy.types.Operator):
             b = random.random()
             new_color = [r, g, b]
             for color in exist_colors:
-                if ((fabs(new_color[0] - color[0]) < allowable)
-                        and (fabs(new_color[1] - color[1]) < allowable)
-                        and (fabs(new_color[2] - color[2]) < allowable)):
+                if ((fabs(new_color[0] - color[0]) < allowable) and
+                        (fabs(new_color[1] - color[1]) < allowable) and
+                        (fabs(new_color[2] - color[2]) < allowable)):
                     break
             else:
                 return new_color

--- a/src/magic_uv/op/uv_inspection.py
+++ b/src/magic_uv/op/uv_inspection.py
@@ -42,18 +42,18 @@ else:
 
 
 def _is_valid_context(context):
+    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
+    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
+    # after the execution
+    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # 'IMAGE_EDITOR' and 'VIEW_3D' space is allowed to execute.
-    # If 'View_3D' space is not allowed, you can't find option in Tool-Shelf
-    # after the execution
-    if not common.is_valid_space(context, ['IMAGE_EDITOR', 'VIEW_3D']):
         return False
 
     return True
@@ -441,9 +441,9 @@ class MUV_OT_UVInspection_PaintUVIsland(bpy.types.Operator):
             b = random.random()
             new_color = [r, g, b]
             for color in exist_colors:
-                if ((fabs(new_color[0] - color[0]) < allowable) and
-                        (fabs(new_color[1] - color[1]) < allowable) and
-                        (fabs(new_color[2] - color[2]) < allowable)):
+                if ((fabs(new_color[0] - color[0]) < allowable)
+                        and (fabs(new_color[1] - color[1]) < allowable)
+                        and (fabs(new_color[2] - color[2]) < allowable)):
                     break
             else:
                 return new_color

--- a/src/magic_uv/op/uv_sculpt.py
+++ b/src/magic_uv/op/uv_sculpt.py
@@ -51,16 +51,16 @@ else:
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+    
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/uv_sculpt.py
+++ b/src/magic_uv/op/uv_sculpt.py
@@ -54,7 +54,7 @@ def _is_valid_context(context):
     # only 'VIEW_3D' space is allowed to execute
     if not common.is_valid_space(context, ['VIEW_3D']):
         return False
-    
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False

--- a/src/magic_uv/op/uvw.py
+++ b/src/magic_uv/op/uvw.py
@@ -42,16 +42,16 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
 
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
-        return False
-
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
         return False
 
     return True

--- a/src/magic_uv/op/world_scale_uv.py
+++ b/src/magic_uv/op/world_scale_uv.py
@@ -42,6 +42,10 @@ from ..utils import compatibility as compat
 
 
 def _is_valid_context_for_measure(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+
     # Multiple objects editing mode is not supported in this feature.
     objs = common.get_uv_editable_objects(context)
     if len(objs) != 1:
@@ -51,14 +55,15 @@ def _is_valid_context_for_measure(context):
     if context.object.mode != 'EDIT':
         return False
 
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
-        return False
 
     return True
 
 
 def _is_valid_context_for_apply(context):
+    # only 'VIEW_3D' space is allowed to execute
+    if not common.is_valid_space(context, ['VIEW_3D']):
+        return False
+        
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False
@@ -67,9 +72,6 @@ def _is_valid_context_for_apply(context):
     if context.object.mode != 'EDIT':
         return False
 
-    # only 'VIEW_3D' space is allowed to execute
-    if not common.is_valid_space(context, ['VIEW_3D']):
-        return False
 
     return True
 

--- a/src/magic_uv/op/world_scale_uv.py
+++ b/src/magic_uv/op/world_scale_uv.py
@@ -55,7 +55,6 @@ def _is_valid_context_for_measure(context):
     if context.object.mode != 'EDIT':
         return False
 
-
     return True
 
 
@@ -71,7 +70,6 @@ def _is_valid_context_for_apply(context):
     # only edit mode is allowed to execute
     if context.object.mode != 'EDIT':
         return False
-
 
     return True
 

--- a/src/magic_uv/op/world_scale_uv.py
+++ b/src/magic_uv/op/world_scale_uv.py
@@ -63,7 +63,7 @@ def _is_valid_context_for_apply(context):
     # only 'VIEW_3D' space is allowed to execute
     if not common.is_valid_space(context, ['VIEW_3D']):
         return False
-        
+
     objs = common.get_uv_editable_objects(context)
     if not objs:
         return False


### PR DESCRIPTION
 
**Description about the pull request**  

In the operator poll functions  "_is_valid_context" was checking for attributes before checking if it was the right context space causing it to fail with "AttributeError" instead of a returning True/False

 So I moved the 'is_valid_space' calls before other context checks so "_is_valid_context" will return False before it checks for attributes that don't exist in the current space.


**Additional comments** [Optional]  
Yea... this was spamming the console with a lot "AttributeError" making it hard to debug my own scripts.