### PR TITLE
Magic UV: Pass correct argument for operator identifier

### DIFF
--- a/src/magic_uv/ui/IMAGE_MT_uvs.py
+++ b/src/magic_uv/ui/IMAGE_MT_uvs.py
@@ -118,7 +118,8 @@ class MUV_MT_AlignUV(bpy.types.Menu):
         ops.group = sc.muv_align_uv_snap_point_group
         ops.target = sc.muv_align_uv_snap_point_target
 
-        ops = layout.operator(MUV_OT_AlignUV_SnapToEdge.bl_idname, text="Snap to Edge")
+        ops = layout.operator(MUV_OT_AlignUV_SnapToEdge.bl_idname,
+                              text="Snap to Edge")
         ops.group = sc.muv_align_uv_snap_edge_group
         ops.target_1 = sc.muv_align_uv_snap_edge_target_1
         ops.target_2 = sc.muv_align_uv_snap_edge_target_2

--- a/src/magic_uv/ui/IMAGE_MT_uvs.py
+++ b/src/magic_uv/ui/IMAGE_MT_uvs.py
@@ -118,7 +118,7 @@ class MUV_MT_AlignUV(bpy.types.Menu):
         ops.group = sc.muv_align_uv_snap_point_group
         ops.target = sc.muv_align_uv_snap_point_target
 
-        ops = layout.operator(MUV_OT_AlignUV_SnapToEdge, text="Snap to Edge")
+        ops = layout.operator(MUV_OT_AlignUV_SnapToEdge.bl_idname, text="Snap to Edge")
         ops.group = sc.muv_align_uv_snap_edge_group
         ops.target_1 = sc.muv_align_uv_snap_edge_target_1
         ops.target_2 = sc.muv_align_uv_snap_edge_target_2


### PR DESCRIPTION
Fix the invalid argument passed in place of operator id.