### PR TITLE
Texture wrap fixes

### DIFF
--- a/src/magic_uv/op/texture_wrap.py
+++ b/src/magic_uv/op/texture_wrap.py
@@ -269,7 +269,7 @@ class MUV_OT_TextureWrap_Set(bpy.types.Operator):
                                         (m_coeffs[2], m_coeffs[3])))
                     break
                 except linalg.LinAlgError:
-                    pass # loop and try a different C
+                    pass    # loop and try a different third vert
 
             if tform_mtx is None:
                 self.report({'WARNING'}, "Invalid reference face")

--- a/src/magic_uv/op/texture_wrap.py
+++ b/src/magic_uv/op/texture_wrap.py
@@ -14,7 +14,7 @@ from bpy.props import (
 )
 import bmesh
 from mathutils import Vector, Matrix
-from numpy.linalg import solve
+from numpy import linalg
 
 from .. import common
 from ..utils.bl_class_registry import BlClassRegistry
@@ -247,10 +247,6 @@ class MUV_OT_TextureWrap_Set(bpy.types.Operator):
                 ab_uv = b_uv - a_uv
                 ac_uv = c_uv - a_uv
 
-                # check for collinear verts
-                if xc_3d.length < 1e-5:
-                    continue
-
                 # find affine transformation from this 2D system to UV
                 #  [u] = [m11 m12] @ [x]
                 #  [v]   [m21 m22]   [y]       [u1]   [x1 y1 0  0 ]   [m11]
@@ -263,11 +259,11 @@ class MUV_OT_TextureWrap_Set(bpy.types.Operator):
                                     (ac_2d.x, ac_2d.y, 0,       0      ),
                                     (0,       0,       ac_2d.x, ac_2d.y)))
                 try:
-                    m_coeffs = solve(matrix_2d, vector_uv)
+                    m_coeffs = linalg.solve(matrix_2d, vector_uv)
                     tform_mtx = Matrix(((m_coeffs[0], m_coeffs[1]),
                                         (m_coeffs[2], m_coeffs[3])))
                     break
-                except:
+                except linalg.LinAlgError:
                     pass # loop and try a different C
 
             if tform_mtx is None:

--- a/src/magic_uv/op/texture_wrap.py
+++ b/src/magic_uv/op/texture_wrap.py
@@ -226,39 +226,53 @@ class MUV_OT_TextureWrap_Set(bpy.types.Operator):
                 self.report({'WARNING'}, "More than 1 vertex must be unshared")
                 return {'CANCELLED'}
 
-            # get reference info
-            a_3d = common_verts[0]["vert"].co
-            b_3d = common_verts[1]["vert"].co
-            c_3d = ref_other_verts[0]["vert"].co
-            a_uv = common_verts[0]["ref_loop"][uv_layer].uv
-            b_uv = common_verts[1]["ref_loop"][uv_layer].uv
-            c_uv = ref_other_verts[0]["loop"][uv_layer].uv
+            tform_mtx = None
+            for other_vert in ref_other_verts:
+                # get reference info
+                a_3d = common_verts[0]["vert"].co
+                b_3d = common_verts[1]["vert"].co
+                c_3d = other_vert["vert"].co
+                a_uv = common_verts[0]["ref_loop"][uv_layer].uv
+                b_uv = common_verts[1]["ref_loop"][uv_layer].uv
+                c_uv = other_vert["loop"][uv_layer].uv
 
-            # AB = shared edge, C = third vert of ref face
-            # set up a 2D coordinate system with coordinates relative to AB
-            # X = C projected onto AB, XC/AX = perpendicular/parallel to AB
-            xc_3d, x_3d = common.diff_point_to_segment(a_3d, b_3d, c_3d)
-            ax_3d = x_3d - a_3d
-            ab_2d = Vector((0.0, (b_3d - a_3d).length))
-            ac_2d = Vector((xc_3d.length,
-                    math.copysign(ax_3d.length, ax_3d.dot(b_3d - a_3d))))
-            ab_uv = b_uv - a_uv
-            ac_uv = c_uv - a_uv
+                # AB = shared edge, C = third vert of ref face
+                # set up a 2D coordinate system with coordinates relative to AB
+                # X = C projected onto AB, XC/AX = perpendicular/parallel to AB
+                xc_3d, x_3d = common.diff_point_to_segment(a_3d, b_3d, c_3d)
+                ax_3d = x_3d - a_3d
+                ab_2d = Vector((0.0, (b_3d - a_3d).length))
+                ac_2d = Vector((xc_3d.length,
+                        math.copysign(ax_3d.length, ax_3d.dot(b_3d - a_3d))))
+                ab_uv = b_uv - a_uv
+                ac_uv = c_uv - a_uv
 
-            # find affine transformation from this 2D system to UV
-            #  [u] = [m11 m12] @ [x]
-            #  [v]   [m21 m22]   [y]       [u1]   [x1 y1 0  0 ]   [m11]
-            #                              [v1] = [0  0  x1 y1] @ [m12]
-            #  u = m11*x + m12*y           [u2]   [x1 y1 0  0 ]   [m21]
-            #  v = m21*x + m22*y           [v2]   [0  0  x1 y1]   [m22]
-            vector_uv = Vector((ab_uv.x, ab_uv.y, ac_uv.x, ac_uv.y))
-            matrix_2d = Matrix(((ab_2d.x, ab_2d.y, 0,       0      ),
-                                (0,       0,       ab_2d.x, ab_2d.y),
-                                (ac_2d.x, ac_2d.y, 0,       0      ),
-                                (0,       0,       ac_2d.x, ac_2d.y)))
-            m_coeffs = solve(matrix_2d, vector_uv)
-            tform_mtx = Matrix(((m_coeffs[0], m_coeffs[1]),
-                                (m_coeffs[2], m_coeffs[3])))
+                # check for collinear verts
+                if xc_3d.length < 1e-5:
+                    continue
+
+                # find affine transformation from this 2D system to UV
+                #  [u] = [m11 m12] @ [x]
+                #  [v]   [m21 m22]   [y]       [u1]   [x1 y1 0  0 ]   [m11]
+                #                              [v1] = [0  0  x1 y1] @ [m12]
+                #  u = m11*x + m12*y           [u2]   [x1 y1 0  0 ]   [m21]
+                #  v = m21*x + m22*y           [v2]   [0  0  x1 y1]   [m22]
+                vector_uv = Vector((ab_uv.x, ab_uv.y, ac_uv.x, ac_uv.y))
+                matrix_2d = Matrix(((ab_2d.x, ab_2d.y, 0,       0      ),
+                                    (0,       0,       ab_2d.x, ab_2d.y),
+                                    (ac_2d.x, ac_2d.y, 0,       0      ),
+                                    (0,       0,       ac_2d.x, ac_2d.y)))
+                try:
+                    m_coeffs = solve(matrix_2d, vector_uv)
+                    tform_mtx = Matrix(((m_coeffs[0], m_coeffs[1]),
+                                        (m_coeffs[2], m_coeffs[3])))
+                    break
+                except:
+                    pass # loop and try a different C
+
+            if tform_mtx is None:
+                self.report({'WARNING'}, "Invalid reference face")
+                return {'CANCELLED'}
 
             # find UVs for target vertices
             for info in tgt_other_verts:

--- a/src/magic_uv/op/texture_wrap.py
+++ b/src/magic_uv/op/texture_wrap.py
@@ -19,6 +19,7 @@ from mathutils import Vector, Matrix
 from .. import common
 from ..utils.bl_class_registry import BlClassRegistry
 from ..utils.property_class_registry import PropertyClassRegistry
+from ..utils import compatibility as compat
 
 
 def _is_valid_context(context):
@@ -282,7 +283,7 @@ class MUV_OT_TextureWrap_Set(bpy.types.Operator):
                 az_3d = z_3d - a_3d
                 ad_2d = Vector((-zd_3d.length,
                                 math.copysign(az_3d.length, az_3d.dot(ab_3d))))
-                ad_uv = tform_mtx @ ad_2d
+                ad_uv = compat.matmul(tform_mtx, ad_2d)
                 d_uv = ad_uv + a_uv
                 info["target_uv"] = d_uv
 


### PR DESCRIPTION
Currently, texture wrap (refer/set) only reliably works for rectangular faces that have perfect undistorted UVs.  

https://user-images.githubusercontent.com/55441216/189711926-30a6be62-e73f-434e-976c-54914719284d.mp4  

The first commit addresses flaws in the existing algorithm. Mainly, it takes into account the fact that projections of original face's third vert and of target face's third vert don't necessarily both lie in the same direction relative to a shared reference vert.

With this fixed, it now works for faces of arbitrary shape. However, it still requires perfect UVs, and something as simple as a non-square texture with aspect-corrected unwrap would break everything.

https://user-images.githubusercontent.com/55441216/189711997-973d12c5-ac49-48fa-8b6b-8e6b1781d9e7.mp4

You can only get so far with rotation and scale, so the second commit replaces the algorithm with one based on finding an affine transformation between spaces. Now it should work reasonably well for arbitrary meshes and UVs.

https://user-images.githubusercontent.com/55441216/189712039-b3a1acb9-0692-47b8-83be-0cf357de101b.mp4
